### PR TITLE
Update config variable plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ the toolbelt. See [Heroku][toolbelt] for details._
 * Create a new Heroku app: `heroku create <appname>`
 * Push the project to Heroku: `git push heroku master -u`
 * Set `APP_URL` in .env to `https://<appname>.herokuapp.com`
-* Add the `heroku-config` plugin: `heroku plugins:install git://github.com/ddollar/heroku-config.git`
+* Add the `heroku-config` plugin: `heroku plugins:install heroku-config`
 * Push the local environment variables to heroku: `heroku config:push`
 
 In the [BigCommerce Developer Portal][devportal], you'll need to update the app's callback URLs:


### PR DESCRIPTION
#### What?
The version of Heroku Config in the Readme no longer works 
[ddollar](https://github.com/ddollar/heroku-config) now directs you to the newest version, which does work after testing on my local machine. The new plugin [heroku-config](https://github.com/xavdid/heroku-config)

#### Console Output

```
AUS-MBP-PERRY:hello-world-app-php-silex tatiana.perry$ heroku plugins:install git://github.com/ddollar/heroku-config.git
Installing git://github.com/ddollar/heroku-config.git@latest... !
 ▸    yarn add git://github.com/ddollar/heroku-config.git@latest --non-interactive
 ▸    --mutex=file:/Users/tatiana.perry/.local/share/heroku/plugins/yarn.lock
 ▸    --preferred-cache-folder=/Users/tatiana.perry/Library/Caches/heroku/yarn
 ▸    --registry=https://cli-npm.heroku.com exited with code 1
 ▸    error Refusing to download the git repo
 ▸    {"hostname":"github.com","protocol":"git:","repository":"git://github.com/ddollar/heroku-config.git@latest"}
 ▸    over plain git without a commit hash
 ▸    
 ▸    yarn add v1.3.2
 ▸    info No lockfile found.
 ▸    [1/4] Resolving packages...
 ▸    info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
 ▸    
AUS-MBP-PERRY:hello-world-app-php-silex tatiana.perry$ heroku plugins:install heroku-config
Installing heroku-config@latest... done
AUS-MBP-PERRY:hello-world-app-php-silex tatiana.perry$ heroku config:push
Successfully wrote settings to Heroku!
```
